### PR TITLE
fix: set the modulator page table name to avoid namespace in table name

### DIFF
--- a/src/ModularPage.php
+++ b/src/ModularPage.php
@@ -20,15 +20,19 @@ class ModularPage extends Page
     /**
      * @var array
      */
-    private static $db = array(
-    );
+    private static $db = [];
 
     /**
      * @var array
      */
-    private static $has_many = array(
+    private static $table_name = "ModularPage";
+
+    /**
+     * @var array
+     */
+    private static $has_many = [
         'Modules' => PageModule::class,
-    );
+    ];
 
     private static $owns = [
         'Modules'
@@ -37,7 +41,7 @@ class ModularPage extends Page
     /**
      * @var array
      */
-    public static $allowed_modules = array();
+    public static $allowed_modules = [];
 
     /**
      * @return FieldList


### PR DESCRIPTION
This will require going back to sites that use modulator to check and fix this db change.

SINZ is the only site that I'm aware of that also uses this module